### PR TITLE
flake.nix: Run gradle using jdk23, rather than adding it to the toolchain

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
         devShells.default = pkgs.mkShell {
           packages = with pkgs ; [
                 (gradle.override {
-                    javaToolchains = [ jdk23 ]; # Put JDK 23 in Gradle's javaToolchain configuration
+                    java =  jdk23 ; # Run Gradle with  JDK 23
                 })
             ];
         };


### PR DESCRIPTION
This seems to resolve the issue. So perhaps there is a difference in how Gradle/Kotlin treats the JDK it is run with versus when it is loaded via `javaToolchains`